### PR TITLE
Simplify ProjectReference to analyzer

### DIFF
--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -6,13 +6,10 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
-  <!-- Add this as a new ItemGroup, replacing paths and names appropriately -->
   <ItemGroup>
-    <Analyzer Include="$(OutDir)\..\..\..\..\InterfaceGenerator\bin\$(Configuration)\netstandard2.0\InterfaceGenerator.dll" />
+    <ProjectReference Include="..\InterfaceGenerator\InterfaceGenerator.csproj" 
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\InterfaceGenerator\InterfaceGenerator.csproj" />
-  </ItemGroup>
-	
 </Project>


### PR DESCRIPTION
Use a `ProjectReference` that doesn't add a code reference (`ReferenceOutputAssembly="false"`) and specifies that the project's output should be added to the analyzer items (`OutputItemType="Analyzer"`) instead of manually referencing the path to the output assembly in a distinct Analyzer item.

(This came up on Twitter: https://twitter.com/davidfowl/status/1256730974609539072)

cc @davidfowl @jaredpar